### PR TITLE
Update HTTP to HTTPS

### DIFF
--- a/src/Messageport.php
+++ b/src/Messageport.php
@@ -17,7 +17,7 @@ class Messageport {
     /**
      * The API base URL
      */
-    const API_URL = 'http://messageport.com.au/rest/v1/';
+    const API_URL = 'https://messageport.com.au/rest/v1/';
 
     /**
      * The API Unique Id


### PR DESCRIPTION
NGINX is redirecting HTTP requests to HTTPS. CURL PHP is getting are error because the redirect option is not set. I though it would just be easier to update the base URL to HTTPS.